### PR TITLE
Start workshop page: cart logic, displaying items

### DIFF
--- a/all-items.json
+++ b/all-items.json
@@ -1,0 +1,16 @@
+{
+  "Chips": [
+    {
+      "title": "Wood Chip",
+      "description": "It's biodegradable.",
+      "image": "here's an image"
+    }
+  ],
+  "Plant Computers": [
+    {
+      "title": "Plant sensor",
+      "description": "It's a plant.",
+      "image": "here's an image"
+    }
+  ]
+}

--- a/server.js
+++ b/server.js
@@ -1,6 +1,7 @@
 const express = require("express");
 const app = express();
 const path = require("path");
+const fs = require("fs");
 
 // to read env variables in .env
 require("dotenv").config();
@@ -11,6 +12,7 @@ const Gift = gifts.Gift;
 
 // use ejs template engine
 app.set("view engine", "ejs");
+app.use(express.static("static"));
 
 // Home page
 app.get("/", async (req, res) => {
@@ -19,7 +21,9 @@ app.get("/", async (req, res) => {
 
 // Workshop page
 app.get("/workshop", async (req, res) => {
-  res.render("workshop");
+  // all items are stored in JSON file
+  const allItems = JSON.parse(fs.readFileSync("all-items.json", "utf8"));
+  res.render("workshop", { allItems: allItems });
 });
 
 // Garden page

--- a/static/app.js
+++ b/static/app.js
@@ -1,0 +1,84 @@
+// Return cart as array from local storage
+function getCart() {
+  if (!("cart" in localStorage)) {
+    return [];
+  }
+  return JSON.parse(localStorage.getItem("cart"));
+}
+
+// Set cart in local storage given cart array
+function setCart(cart) {
+  localStorage.setItem("cart", JSON.stringify(cart));
+}
+
+// Adds an item to user's cart
+// Assumes cart is stored as list of items
+// Assumes user cannot add an item more than once
+function addToCart() {
+  $(".buy-btn").on("click", function () {
+    const item = $(this).attr("data-item");
+
+    const cart = getCart();
+    cart.push(item);
+    setCart(cart);
+
+    // disable button, change text
+    $(this).attr("disabled", true);
+    $(this).html("Added");
+  });
+}
+
+// Remove item from cart
+function removeFromCart() {
+  $(".remove-btn").on("click", function () {
+    const itemToRemove = $(this).attr("data-item");
+
+    const cart = getCart();
+    setCart(
+      cart.filter((item) => {
+        return item != itemToRemove;
+      })
+    );
+
+    // hide item from cart pop-up and enable Add to Cart button
+    $(this).parent(".cart-item-container").attr("hidden", true);
+    const btnSelector = `.buy-btn[data-item="${itemToRemove}"]`;
+    $(btnSelector).attr("disabled", false);
+    $(btnSelector).html("Add to Cart");
+  });
+}
+
+// Show cart as pop-up
+function showCart() {
+  $("#cart-btn").on("click", function () {
+    const cart = getCart();
+
+    // hide items that aren't in cart
+    $(".cart-item-container").each(function () {
+      const item = $(this).attr("data-item");
+      $(this).attr("hidden", !cart.includes(item));
+    });
+
+    // show cart items in pop-up
+    $("#cart-modal").modal("show");
+  });
+}
+
+// Disable Add to Cart button for any items already in cart
+function disableAddToCart() {
+  $(".buy-btn").each(function () {
+    const cart = getCart();
+    const item = $(this).attr("data-item");
+    if (cart.includes(item)) {
+      $(this).attr("disabled", true);
+      $(this).html("Added");
+    }
+  });
+}
+
+$(function () {
+  addToCart();
+  removeFromCart();
+  showCart();
+  disableAddToCart();
+});

--- a/views/partials/head.ejs
+++ b/views/partials/head.ejs
@@ -3,4 +3,16 @@
 <title></title>
 <meta name="description" content="" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
-<link rel="stylesheet" href="" />
+<!-- Bootstrap -->
+<link
+  href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css"
+  rel="stylesheet"
+  integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC"
+  crossorigin="anonymous"
+/>
+<!-- Bundle with Popper -->
+<script
+  src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js"
+  integrity="sha384-ka7Sk0Gln4gmtz2MlQnikT1wXgYsOg+OMhuP+IlRH9sENBO0LRn5q+8nbTov4+1p"
+  crossorigin="anonymous"
+></script>

--- a/views/partials/scripts.ejs
+++ b/views/partials/scripts.ejs
@@ -1,2 +1,4 @@
-<!-- Import JS files here -->
-<script src="" async defer></script>
+<!-- JQuery -->
+<script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+<!-- Our own JS methods -->
+<script src="app.js" type="text/javascript"></script>

--- a/views/workshop.ejs
+++ b/views/workshop.ejs
@@ -1,10 +1,95 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <%- include('partials/head'); %>
+    <%- include('partials/head'); %> <%- include('partials/scripts'); %>
   </head>
   <body>
     <h1>Workshop page</h1>
-    <%- include('partials/scripts'); %>
+
+    <!-- Click to open Cart modal (below) -->
+    <button id="cart-btn" type="button" class="btn btn-primary">
+      Show Cart
+    </button>
+
+    <!-- Customize gallery here -->
+    <div id="gallery-container">
+      <% for (category in allItems) { %>
+      <div><strong class="item-category"><%= category %></strong></div>
+      <% allItems[category].forEach(function(item) { %>
+      <div
+        class="item-container"
+        data-category="<%=category%>"
+        data-item="<%=item.title%>"
+      >
+        <div class="item-title"><%= item.title %></div>
+        <div class="item-description"><%=item.description%></div>
+        <div class="item-image"><%=item.image%></div>
+        <button
+          type="button"
+          class="buy-btn btn btn-primary"
+          data-category="<%=category%>"
+          data-item="<%=item.title%>"
+        >
+          Add to Cart
+        </button>
+      </div>
+      <% }); %> <% } %>
+    </div>
+
+    <!-- Cart Modal -->
+    <div
+      class="modal fade"
+      id="cart-modal"
+      tabindex="-1"
+      aria-labelledby="exampleModalLabel"
+      aria-hidden="true"
+    >
+      <div class="modal-dialog">
+        <div class="modal-content">
+          <div class="modal-header">
+            <h5 class="modal-title" id="exampleModalLabel">My Cart</h5>
+            <button
+              type="button"
+              class="btn-close"
+              data-bs-dismiss="modal"
+              aria-label="Close"
+            ></button>
+          </div>
+          <div id="cart-body" class="modal-body">
+            <!-- By default, all items are added to Cart modal body. -->
+            <!-- In app.js, we hide any items not in cart. -->
+            <% for (category in allItems) { %> <%
+            allItems[category].forEach(function(item) { %>
+            <div
+              class="cart-item-container"
+              data-category="<%=category%>"
+              data-item="<%=item.title%>"
+            >
+              <div class="cart-item-title"><%= item.title %></div>
+              <div class="cart-item-category">Category: <%= category %></div>
+              <div class="cart-item-image"><%=item.image%></div>
+              <button
+                type="button"
+                class="remove-btn btn btn-primary"
+                data-category="<%=category%>"
+                data-item="<%=item.title%>"
+              >
+                Remove from Cart
+              </button>
+            </div>
+            <% }); %> <% } %>
+          </div>
+          <div class="modal-footer">
+            <button
+              type="button"
+              class="btn btn-secondary"
+              data-bs-dismiss="modal"
+            >
+              Close
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
   </body>
 </html>


### PR DESCRIPTION
**Major Changes**
- All item names, descriptions, and images are stored in `all-items.json`. We read in this data in `server.js` and can pass it to any of our ejs templates for use on the front-end.
- `app.js` stores our own JS methods, used to listen for events and traverse the DOM. 
- We set up basic cart logic, so users can simply **add an item** to cart, **remove an item** from cart, **view current items** in the cart with a click of a button. We're storing the user's cart items in `localStorage`. For example:

![start-cart](https://user-images.githubusercontent.com/63625700/161412408-83084618-dc9d-4643-baa8-e7c1cd77dec0.gif)